### PR TITLE
fix: Remove unused global_var import in general.go

### DIFF
--- a/pkg/utils/general.go
+++ b/pkg/utils/general.go
@@ -12,11 +12,12 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/big"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/cakramediadata2022/chs_cloud_general/pkg/global_var"
+	// "github.com/cakramediadata2022/chs_cloud_general/pkg/global_var"
 	"github.com/go-playground/validator/v10"
 
 	"github.com/gin-gonic/gin"


### PR DESCRIPTION
Commented out the import of global_var package in pkg/utils/general.go as it is not currently used. This helps clean up the code and avoid unnecessary dependencies.